### PR TITLE
fix: Added default value to the --libs cli parameter

### DIFF
--- a/pinion/ui.py
+++ b/pinion/ui.py
@@ -78,7 +78,7 @@ def generateCommandArgs(func):
 @click.option("--dpi", type=int, default=300,
     help="DPI of the generated board image")
 @click.option("--style", help="PcbDraw style specification")
-@click.option("--libs", type=CliList(),
+@click.option("--libs", type=CliList(), default="KiCAD-base",
     help="PcbDraw library specification")
 @click.option("--remap", help="PcbDraw footprint remapping specification")
 @click.option("--filter", help="PcbDraw filter specification")


### PR DESCRIPTION
No default value for the --libs cli parameter caused the resulting variable to be of value None. This is not caught in PcbDraw, which attempts to iterate over the list of libraries, and so crashes.

The default value for the parameter is taken from PcbDraw introduced in this [commit](https://github.com/yaqwsx/PcbDraw/commit/57da7cf2da61dec896c6f011d6c7fbff4bf2fa2b).

Fixes https://github.com/yaqwsx/Pinion/issues/35
